### PR TITLE
Docker support enhancement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,22 @@ WORKDIR /InnerSource
 ADD Gemfile .
 ADD Gemfile.lock .
 
+# Required in order to build gem native extenstions
+# see https://github.com/docker-library/ruby/issues/163
 RUN apk add --no-cache g++ gcc make musl-dev
+
+# Required to build in Docker for Mac, otherwise it will raise the
+# error: Could not find 'bundler'
 RUN bundle update --bundler
+
 RUN bundle install
 
-CMD jekyll serve --host 0.0.0.0 --config /source/_config.yml,/source/_config_dev.yml -s /source -d /dist
+# Required so that Jekyll will not override site.url with the host passed by --host
+ENV JEKYLL_ENV=docker
+
+EXPOSE 35729
+EXPOSE 4000
+
+# On --host 0.0.0.0
+# It is required so that Jekyll will accept connections outside of localhost and 127.0.0.1
+CMD jekyll serve --host 0.0.0.0 --livereload --config /source/_config.yml,/source/_config_dev.yml -s /source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     image: innersource-website-devenv
     ports:
-    - "4000:4000"
+    - "4000:4000" # webpage
+    - "35729:35729" # live reload
     volumes:
     - ./:/source


### PR DESCRIPTION
Added future proof support to Docker for windows
with setting `JEKYLL_ENV` to a value different than
`development`.
With this setting, the ip used in `--host` is not
going to override site.url.
The alternative would be use `build --watch` + a separate
web server for static files, but I did not see any advantage,
and also I wanted to have the livereload option of `serve`.

Added comments on the Dockerfile to explain some
of the non-intuitive parts.

Added support for livereload.

Added EXPOSE statements to the Dockerfile to document ports in use.

References:
- https://jekyllrb.com/docs/configuration/options/#serve-command-options
- https://tonyho.net/jekyll-docker-windows-and-0-0-0-0/
- Cannot set site.url to a different address than the --host flag address in development
  - https://github.com/jekyll/jekyll/issues/5743
- https://docs.docker.com/engine/reference/builder/#expose